### PR TITLE
Make .NET standard 2 compatible

### DIFF
--- a/Ps2IsoTools/Extensions/ArrayExtensions.cs
+++ b/Ps2IsoTools/Extensions/ArrayExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace Ps2IsoTools.Extensions
+{
+    internal static class ArrayExtensions
+    {
+        public static byte[] Slice(this byte[] source, int start, int end)
+        {
+            var len = end - start;
+            var result = new byte[len];
+            Array.Copy(source, start, result, 0, len);
+            return result;
+        }
+    }
+}

--- a/Ps2IsoTools/ISO/Files/Directory.cs
+++ b/Ps2IsoTools/ISO/Files/Directory.cs
@@ -40,10 +40,10 @@ namespace Ps2IsoTools.ISO.Files
         public DirectoryEntry? GetEntryByName(string Name)
         {
             if (Name.Contains(";"))
-                Name = Name.Split(";")[0];
+                Name = Name.Split(';')[0];
             foreach (DirectoryEntry fi in Entries)
             {
-                if (string.Compare(Name, fi.Name.Split(";")[0], StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Compare(Name, fi.Name.Split(';')[0], StringComparison.OrdinalIgnoreCase) == 0)
                     return fi;
             }
             return null;

--- a/Ps2IsoTools/ISO/Files/DirectoryEntry.cs
+++ b/Ps2IsoTools/ISO/Files/DirectoryEntry.cs
@@ -1,5 +1,6 @@
-﻿using Ps2IsoTools.DiscUtils.Utils;
-using System.Text;
+﻿using System.Text;
+using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 
 namespace Ps2IsoTools.ISO.Files
 {
@@ -38,7 +39,7 @@ namespace Ps2IsoTools.ISO.Files
             VolumeSequenceNumber = EndianUtilities.ToUInt16LittleEndian(buffer, offset + 28);
             //VolumeSequenceNumberBigEnd = EndianUtilities.ToUInt16BigEndian(buffer, offset + 30);
             NameLength = buffer[offset + 32];
-            Name = Encoding.Default.GetString(buffer[(offset + 33)..(offset + 33 + NameLength)]);
+            Name = Encoding.Default.GetString(buffer.Slice((offset + 33), (offset + 33 + NameLength)));
             SystemUseData = new byte[EntryLength - Size];
 
             return Size;

--- a/Ps2IsoTools/ISO/Files/PathTableEntry.cs
+++ b/Ps2IsoTools/ISO/Files/PathTableEntry.cs
@@ -1,5 +1,6 @@
-﻿using Ps2IsoTools.DiscUtils.Utils;
-using System.Text;
+﻿using System.Text;
+using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 
 namespace Ps2IsoTools.ISO.Files
 {
@@ -28,7 +29,7 @@ namespace Ps2IsoTools.ISO.Files
             }
             else
                 ParentIndex = EndianUtilities.ToInt16LittleEndian(buffer, offset + 6);
-            PathName = Encoding.Default.GetString(buffer[(offset + 8)..(offset + 8 + NameLength)]);
+            PathName = Encoding.Default.GetString(buffer.Slice((offset + 8), (offset + 8 + NameLength)));
 
             return Size;
         }

--- a/Ps2IsoTools/ISO/IsoReader.cs
+++ b/Ps2IsoTools/ISO/IsoReader.cs
@@ -17,10 +17,10 @@ namespace Ps2IsoTools.ISO
             byte[] buffer = new byte[SectorSize];
             ms = File.Open(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
             ms.Position = 0x10 * SectorSize;
-            ms.Read(buffer);
+            ms.Read(buffer, 0, buffer.Length);
             PVD = new ISO.VolumeDescriptors.PrimaryVolumeDescriptor(buffer, 0);
             ms.Position = PVD.TypeLPathTableLocation * PVD.LogicalBlockSize;
-            ms.Read(buffer);
+            ms.Read(buffer, 0, buffer.Length);
             PathTable = new PathTable();
             PathTable.ReadFrom(buffer, 0);
 
@@ -29,7 +29,7 @@ namespace Ps2IsoTools.ISO
             foreach (PathTableEntry entry in PathTable.Entries)
             {
                 ms.Position = entry.DirectoryLocation * PVD.LogicalBlockSize;
-                ms.Read(buffer);
+                ms.Read(buffer, 0, buffer.Length);
                 Directory dir = new();
                 dir.ReadFrom(buffer, 0);
                 directories.Add(dir);
@@ -39,7 +39,7 @@ namespace Ps2IsoTools.ISO
         public bool CopyFile(DirectoryEntry file, string filePath = "")
         {
             if (filePath == "")
-                filePath = file.Name.Split(";")[0];
+                filePath = file.Name.Split(';')[0];
             FileInfo fi = new FileInfo(filePath);
             using (FileStream stream = fi.Create())
             {
@@ -91,7 +91,7 @@ namespace Ps2IsoTools.ISO
                 return GetFileLocationNoPath(path[0]);
 
             Directory? dir = directories[0];
-            DirectoryEntry? entry = null; 
+            DirectoryEntry? entry = null;
             for (int i = 0; i < path.Length; i++)
             {
                 entry = dir?.GetEntryByName(path[i]);
@@ -123,7 +123,7 @@ namespace Ps2IsoTools.ISO
 
         public Directory? GetDirectoryByIdentifier(DirectoryEntry fileIdentifier)
         {
-            foreach(Directory dir in directories)
+            foreach (Directory dir in directories)
             {
                 if (dir.Identifier.Equals(fileIdentifier))
                     return dir;

--- a/Ps2IsoTools/ISO/VolumeDescriptors/BaseVolumeDescriptor.cs
+++ b/Ps2IsoTools/ISO/VolumeDescriptors/BaseVolumeDescriptor.cs
@@ -20,8 +20,9 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using Ps2IsoTools.DiscUtils.Utils;
 using System.Text;
+using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 
 namespace Ps2IsoTools.ISO.VolumeDescriptors
 {
@@ -48,7 +49,7 @@ namespace Ps2IsoTools.ISO.VolumeDescriptors
         public BaseVolumeDescriptor(byte[] buffer, int offset)
         {
             VolumeDescriptorType = (VolumeDescriptorType)buffer[offset];
-            Identifier = Encoding.ASCII.GetString(buffer[(offset + 1)..(offset + 6)]);
+            Identifier = Encoding.ASCII.GetString(buffer.Slice((offset + 1), (offset + 6)));
             VolumeDescriptorVersion = buffer[offset + 6];
         }
         internal virtual void WriteTo(byte[] buffer, int offset)

--- a/Ps2IsoTools/ISO/VolumeDescriptors/CommonVolumeDescriptor.cs
+++ b/Ps2IsoTools/ISO/VolumeDescriptors/CommonVolumeDescriptor.cs
@@ -20,10 +20,11 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System.Text;
 using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 using Ps2IsoTools.ISO.Builders;
 using Ps2IsoTools.ISO.Files;
-using System.Text;
 
 namespace Ps2IsoTools.ISO.VolumeDescriptors
 {
@@ -59,8 +60,8 @@ namespace Ps2IsoTools.ISO.VolumeDescriptors
             Encoding = enc;
             RootDirectory = new();
 
-            SystemIdentifier = enc.GetString(buffer[(offset + 8)..(offset + 40)]).TrimEnd();
-            VolumeIdentifier = enc.GetString(buffer[(offset + 40)..(offset + 72)]).TrimEnd();
+            SystemIdentifier = enc.GetString(buffer.Slice((offset + 8), (offset + 40))).TrimEnd();
+            VolumeIdentifier = enc.GetString(buffer.Slice((offset + 40), (offset + 72))).TrimEnd();
             //72 - 79 Unused
             VolumeSize = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 80);
             //88 - 119 Unused
@@ -74,13 +75,13 @@ namespace Ps2IsoTools.ISO.VolumeDescriptors
             TypeMOptionalPathTableLocation = EndianUtilities.ToUInt32BigEndian(buffer, offset + 152);
             //RootDirectory.ReadFrom(buffer, offset + 156); //RootDirectory used to be a DirectoryEntry
             DirectoryRecord.ReadFrom(buffer, offset + 156, Encoding, out RootDirectory);
-            VolumeSetIdentifier = enc.GetString(buffer[(offset + 190)..(offset + 318)]).TrimEnd();
-            PublisherIdentifier = enc.GetString(buffer[(offset + 318)..(offset + 446)]).TrimEnd();
-            DataPreparerIdentifier = enc.GetString(buffer[(offset + 446)..(offset + 574)]).TrimEnd();
-            ApplicationIdentifier = enc.GetString(buffer[(offset + 574)..(offset + 702)]).TrimEnd();
-            CopyrightFileIdentifier = enc.GetString(buffer[(offset + 702)..(offset + 739)]).TrimEnd();
-            AbstractFileIdentifier = enc.GetString(buffer[(offset + 739)..(offset + 776)]).TrimEnd();
-            BibliographicFileIdentifier = enc.GetString(buffer[(offset + 776)..(offset + 813)]).TrimEnd();
+            VolumeSetIdentifier = enc.GetString(buffer.Slice((offset + 190), (offset + 318))).TrimEnd();
+            PublisherIdentifier = enc.GetString(buffer.Slice((offset + 318), (offset + 446))).TrimEnd();
+            DataPreparerIdentifier = enc.GetString(buffer.Slice((offset + 446), (offset + 574))).TrimEnd();
+            ApplicationIdentifier = enc.GetString(buffer.Slice((offset + 574), (offset + 702))).TrimEnd();
+            CopyrightFileIdentifier = enc.GetString(buffer.Slice((offset + 702), (offset + 739))).TrimEnd();
+            AbstractFileIdentifier = enc.GetString(buffer.Slice((offset + 739), (offset + 776))).TrimEnd();
+            BibliographicFileIdentifier = enc.GetString(buffer.Slice((offset + 776), (offset + 813))).TrimEnd();
             CreationDateAndTime = IsoUtilities.ToDateTimeFromVolumeDescriptorTime(buffer, offset + 813);
             ModificationDateAndTime = IsoUtilities.ToDateTimeFromVolumeDescriptorTime(buffer, offset + 830);
             ExpirationDateAndTime = IsoUtilities.ToDateTimeFromVolumeDescriptorTime(buffer, offset + 847);

--- a/Ps2IsoTools/Ps2IsoTools.csproj
+++ b/Ps2IsoTools/Ps2IsoTools.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-	<AssemblyVersion>1.0.1</AssemblyVersion>
-	<VersionPrefix>$(AssemblyVersion)</VersionPrefix>
+    <AssemblyVersion>1.0.1</AssemblyVersion>
+    <VersionPrefix>$(AssemblyVersion)</VersionPrefix>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Title>PS2 ISO Tools</Title>
     <Authors>Vi Ness</Authors>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<TargetFramework>net6.0</TargetFramework>
-	<Copyright>MIT</Copyright>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
-	<PackageTags>ISO;UDF;PS2</PackageTags>
-	<RepositoryUrl>https://github.com/Finzenku/Ps2IsoTools</RepositoryUrl>
-	<Description>Tools to Read, Build, and Edit PS2 ISOs that use the UDF file system.</Description>
-	<PackageIcon>ps2.png</PackageIcon>
-	<PackageReleaseNotes>Added description and icon</PackageReleaseNotes>
-	<RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
+    <Copyright>MIT</Copyright>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>ISO;UDF;PS2</PackageTags>
+    <RepositoryUrl>https://github.com/Finzenku/Ps2IsoTools</RepositoryUrl>
+    <Description>Tools to Read, Build, and Edit PS2 ISOs that use the UDF file system.</Description>
+    <PackageIcon>ps2.png</PackageIcon>
+    <PackageReleaseNotes>Added description and icon</PackageReleaseNotes>
+    <RepositoryType>git</RepositoryType>
+    <NoWarn>114;169;649;8600;8601;8603;8604;8618;8625</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
     <None Include="..\README.md">
       <Pack>True</Pack>
@@ -30,5 +30,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
 </Project>

--- a/Ps2IsoTools/UDF/CharacterSet/CharacterSetSpecification.cs
+++ b/Ps2IsoTools/UDF/CharacterSet/CharacterSetSpecification.cs
@@ -1,5 +1,6 @@
-﻿using Ps2IsoTools.DiscUtils.Utils;
-using System.Text;
+﻿using System.Text;
+using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 
 namespace Ps2IsoTools.UDF.CharacterSet
 {
@@ -20,7 +21,7 @@ namespace Ps2IsoTools.UDF.CharacterSet
         public int ReadFrom(byte[] buffer, int offset)
         {
             Type = (CharacterSetType)buffer[offset];
-            Information = buffer[(offset + 1)..(offset + 64)];
+            Information = buffer.Slice((offset + 1), (offset + 64));
 
             return Size;
         }

--- a/Ps2IsoTools/UDF/Descriptors/FileStructure/ExtendedAttribute/ExtendedAttributeRecord.cs
+++ b/Ps2IsoTools/UDF/Descriptors/FileStructure/ExtendedAttribute/ExtendedAttributeRecord.cs
@@ -1,4 +1,5 @@
 ﻿using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 
 namespace Ps2IsoTools.UDF.Descriptors.FileStructure.ExtendedAttribute
 {
@@ -19,7 +20,7 @@ namespace Ps2IsoTools.UDF.Descriptors.FileStructure.ExtendedAttribute
             AttributeType = EndianUtilities.ToUInt32LittleEndian(buffer, offset);
             AttributeSubType = buffer[offset + 4];
             recordLength = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 8);
-            AttributeData = buffer[(offset + 12)..(offset + (int)recordLength - 1)];
+            AttributeData = buffer.Slice((offset + 12), (offset + (int)recordLength - 1));
 
             return Size;
         }

--- a/Ps2IsoTools/UDF/Descriptors/FileStructure/ExtendedAttribute/ExtendedAttributes.cs
+++ b/Ps2IsoTools/UDF/Descriptors/FileStructure/ExtendedAttribute/ExtendedAttributes.cs
@@ -1,4 +1,5 @@
 ﻿using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 using Ps2IsoTools.UDF.EntityIdentifiers;
 
 namespace Ps2IsoTools.UDF.Descriptors.FileStructure.ExtendedAttribute
@@ -49,14 +50,14 @@ namespace Ps2IsoTools.UDF.Descriptors.FileStructure.ExtendedAttribute
             HeaderDescriptor = EndianUtilities.ToStruct<ExtendedAttributeHeaderDescriptor>(buffer, offset);
             if (HeaderDescriptor.ImplementationAttributesLocation < Size)
             {
-                byte[] impData = buffer[(int)(offset + HeaderDescriptor.ImplementationAttributesLocation)..(int)(offset + HeaderDescriptor.ApplicationAttributesLocation)];
+                var impData = buffer.Slice((int)(offset + HeaderDescriptor.ImplementationAttributesLocation), (int)(offset + HeaderDescriptor.ApplicationAttributesLocation));
                 ImplementationAttributes = ReadExtendedAttributesList(impData, true);
             }
             else
                 ImplementationAttributes = new();
             if (HeaderDescriptor.ApplicationAttributesLocation < Size)
             {
-                byte[] appData = buffer[(int)(offset + HeaderDescriptor.ApplicationAttributesLocation)..(offset + Size - 1)];
+                var appData = buffer.Slice((int)(offset + HeaderDescriptor.ApplicationAttributesLocation), (offset + Size - 1));
                 ImplementationAttributes = ReadExtendedAttributesList(appData, false);
             }
             else

--- a/Ps2IsoTools/UDF/Descriptors/FileStructure/ExtendedAttribute/ImplementationUseExtendedAttributeRecord.cs
+++ b/Ps2IsoTools/UDF/Descriptors/FileStructure/ExtendedAttribute/ImplementationUseExtendedAttributeRecord.cs
@@ -1,4 +1,5 @@
 ﻿using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 using Ps2IsoTools.UDF.EntityIdentifiers;
 
 namespace Ps2IsoTools.UDF.Descriptors.FileStructure.ExtendedAttribute
@@ -28,7 +29,7 @@ namespace Ps2IsoTools.UDF.Descriptors.FileStructure.ExtendedAttribute
             iuSize = EndianUtilities.ToInt32LittleEndian(buffer, offset + 12);
 
             ImplementationIdentifier = EndianUtilities.ToStruct<ImplementationEntityIdentifier>(buffer, offset + 16);
-            ImplementationUseData = buffer[(offset + 48)..(offset + 48 + iuSize)];
+            ImplementationUseData = buffer.Slice((offset + 48), (offset + 48 + iuSize));
 
             return read;
         }

--- a/Ps2IsoTools/UDF/Descriptors/FileStructure/FileEntry.cs
+++ b/Ps2IsoTools/UDF/Descriptors/FileStructure/FileEntry.cs
@@ -1,4 +1,5 @@
 ﻿using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 using Ps2IsoTools.UDF.Descriptors.FileStructure.ExtendedAttribute;
 using Ps2IsoTools.UDF.EntityIdentifiers;
 using Ps2IsoTools.UDF.Time;
@@ -47,8 +48,8 @@ namespace Ps2IsoTools.UDF.Descriptors.FileStructure
             Uid = uint.MaxValue;
             Gid = uint.MaxValue;
             Permissions = FilePermissions.OthersExecute | FilePermissions.OthersRead |
-                          FilePermissions.GroupExecute  | FilePermissions.GroupRead  |
-                          FilePermissions.OwnerExecute  | FilePermissions.OwnerRead;
+                          FilePermissions.GroupExecute | FilePermissions.GroupRead |
+                          FilePermissions.OwnerExecute | FilePermissions.OwnerRead;
             FileLinkCount = 1;
             RecordFormat = 0;
             RecordDisplayAttributes = 0;
@@ -81,14 +82,14 @@ namespace Ps2IsoTools.UDF.Descriptors.FileStructure
             Uid = uint.MaxValue;
             Gid = uint.MaxValue;
             Permissions = FilePermissions.OthersExecute | FilePermissions.OthersRead |
-                          FilePermissions.GroupExecute  | FilePermissions.GroupRead  |
-                          FilePermissions.OwnerExecute  | FilePermissions.OwnerRead;
+                          FilePermissions.GroupExecute | FilePermissions.GroupRead |
+                          FilePermissions.OwnerExecute | FilePermissions.OwnerRead;
             FileLinkCount = 1;
             RecordFormat = 0;
             RecordDisplayAttributes = 0;
             RecordLength = 0;
             InformationLength = allocationDescriptor.ExtentLength;
-            LogicalBlocksRecorded = (ulong)MathUtilities.RoundUp((int)InformationLength, IsoUtilities.SectorSize)/IsoUtilities.SectorSize;
+            LogicalBlocksRecorded = (ulong)MathUtilities.RoundUp((int)InformationLength, IsoUtilities.SectorSize) / IsoUtilities.SectorSize;
             DateTime utcNow = DateTime.UtcNow;
             AccessTime = TimeStamp.FromDateTime(utcNow);
             ModificationTime = TimeStamp.FromDateTime(utcNow);
@@ -129,8 +130,8 @@ namespace Ps2IsoTools.UDF.Descriptors.FileStructure
             LengthofAllocationDescriptors = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 172);
             ExtendedAttributes = new((int)LengthofExtendedAttributes);
             ExtendedAttributes.ReadFrom(buffer, offset + 176);
-            //ExtendedAttributesList = ReadExtendedAttributes(buffer[(offset + 176)..(offset + 176 + (int)LengthofExtendedAttributes)]);
-            AllocationDescriptors = buffer[(offset + 176 + (int)LengthofExtendedAttributes)..(offset + 176 + (int)LengthofExtendedAttributes + (int)LengthofAllocationDescriptors)];
+            //ExtendedAttributesList = ReadExtendedAttributes(buffer.Slice((offset + 176), (offset + 176 + (int)LengthofExtendedAttributes)));
+            AllocationDescriptors = buffer.Slice((offset + 176 + (int)LengthofExtendedAttributes), (offset + 176 + (int)LengthofExtendedAttributes + (int)LengthofAllocationDescriptors));
 
             return Size;
         }

--- a/Ps2IsoTools/UDF/Descriptors/FileStructure/FileIdentifierDescriptor.cs
+++ b/Ps2IsoTools/UDF/Descriptors/FileStructure/FileIdentifierDescriptor.cs
@@ -1,6 +1,7 @@
-﻿using Ps2IsoTools.DiscUtils.Utils;
+﻿using System.Text;
+using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 using Ps2IsoTools.UDF.Strings;
-using System.Text;
 
 namespace Ps2IsoTools.UDF.Descriptors.FileStructure
 {
@@ -17,7 +18,7 @@ namespace Ps2IsoTools.UDF.Descriptors.FileStructure
 
         public override int Size => MathUtilities.RoundUp(38 + LengthofImplementationUse + LengthofFileIdentifier, 4);
 
-        public FileIdentifierDescriptor() : base(TagIdentifier.FileIdentifierDescriptor) 
+        public FileIdentifierDescriptor() : base(TagIdentifier.FileIdentifierDescriptor)
         {
             FileVersionNumber = 1;
         }
@@ -33,7 +34,7 @@ namespace Ps2IsoTools.UDF.Descriptors.FileStructure
 
             FileVersionNumber = 1;
             FileCharacteristics = fileType;
-            fileName = fileName.Split(";")[0];
+            fileName = fileName.Split(';')[0];
             FileIdentifier = new Dstring(fileName, CompressionID.UTF16);
             LengthofFileIdentifier = (byte)FileIdentifier.DataLength;
             InformationControlBlock = fileLocation;
@@ -52,7 +53,7 @@ namespace Ps2IsoTools.UDF.Descriptors.FileStructure
             LengthofFileIdentifier = buffer[offset + 19];
             InformationControlBlock = EndianUtilities.ToStruct<LongAllocationDescriptor>(buffer, offset + 20);
             LengthofImplementationUse = EndianUtilities.ToUInt16LittleEndian(buffer, offset + 36);
-            ImplementationUse = buffer[(offset + 38)..(offset + 38 + LengthofImplementationUse)];
+            ImplementationUse = buffer.Slice((offset + 38), (offset + 38 + LengthofImplementationUse));
             FileIdentifier = Dstring.FromBytes(buffer, offset + 38 + LengthofImplementationUse, LengthofFileIdentifier);
 
             return Size;

--- a/Ps2IsoTools/UDF/Descriptors/FileStructure/FileSetDescriptor.cs
+++ b/Ps2IsoTools/UDF/Descriptors/FileStructure/FileSetDescriptor.cs
@@ -1,4 +1,5 @@
 ﻿using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 using Ps2IsoTools.UDF.CharacterSet;
 using Ps2IsoTools.UDF.EntityIdentifiers;
 using Ps2IsoTools.UDF.Strings;
@@ -52,8 +53,8 @@ namespace Ps2IsoTools.UDF.Descriptors.FileStructure
             AbstractFileIdentifier = new Dstring(abstractFileIdentifier, CompressionID.UTF8, 32);
             RootDirectoryICB = rootDirectoryICB;
             DomainIdentifier = CommonIdentifiers.OSTAUDFCompliant;
-            NextExtent = nextFileSetDescriptor??new();
-            SystemStreamDirectoryICB = systemStreamDirectoryICB??new();
+            NextExtent = nextFileSetDescriptor ?? new();
+            SystemStreamDirectoryICB = systemStreamDirectoryICB ?? new();
 
             FixChecksums();
         }
@@ -77,7 +78,7 @@ namespace Ps2IsoTools.UDF.Descriptors.FileStructure
             DomainIdentifier = EndianUtilities.ToStruct<DomainEntityIdentifier>(buffer, offset + 416);
             NextExtent = EndianUtilities.ToStruct<LongAllocationDescriptor>(buffer, offset + 448);
             SystemStreamDirectoryICB = EndianUtilities.ToStruct<LongAllocationDescriptor>(buffer, offset + 464);
-            Reserved = buffer[(offset + 480)..(offset + 512)];
+            Reserved = buffer.Slice((offset + 480), (offset + 512));
 
             return Size;
         }

--- a/Ps2IsoTools/UDF/Descriptors/LongAllocationDescriptor.cs
+++ b/Ps2IsoTools/UDF/Descriptors/LongAllocationDescriptor.cs
@@ -1,4 +1,5 @@
 ﻿using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 
 namespace Ps2IsoTools.UDF.Descriptors
 {
@@ -22,7 +23,7 @@ namespace Ps2IsoTools.UDF.Descriptors
         {
             ExtentLength = EndianUtilities.ToUInt32LittleEndian(buffer, offset);
             ExtentLocation = EndianUtilities.ToStruct<LogicalBlockAddress>(buffer, offset + 4);
-            ImplementationUse = buffer[(offset + 10)..(offset + 16)];
+            ImplementationUse = buffer.Slice((offset + 10), (offset + 16));
 
             return Size;
         }

--- a/Ps2IsoTools/UDF/Descriptors/TaggedDescriptor.cs
+++ b/Ps2IsoTools/UDF/Descriptors/TaggedDescriptor.cs
@@ -20,8 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using Ps2IsoTools.DiscUtils.Utils;
 using System.Globalization;
+using Ps2IsoTools.DiscUtils.Utils;
 
 namespace Ps2IsoTools.UDF.Descriptors
 {
@@ -33,7 +33,7 @@ namespace Ps2IsoTools.UDF.Descriptors
         {
             stream.Position = sector * (long)sectorSize;
             byte[] buffer = new byte[sectorSize];
-            stream.Read(buffer);
+            stream.Read(buffer, 0, buffer.Length);
             T result = EndianUtilities.ToStruct<T>(buffer, 0);
             if (result.Tag.TagIdentifier != result.RequiredTagIdentifier || result.Tag.TagLocation != sector)
             {

--- a/Ps2IsoTools/UDF/Descriptors/VolumeStructure/LVInformation.cs
+++ b/Ps2IsoTools/UDF/Descriptors/VolumeStructure/LVInformation.cs
@@ -1,4 +1,5 @@
 ﻿using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 using Ps2IsoTools.UDF.CharacterSet;
 using Ps2IsoTools.UDF.EntityIdentifiers;
 using Ps2IsoTools.UDF.Strings;
@@ -36,7 +37,7 @@ namespace Ps2IsoTools.UDF.Descriptors
             LVInfo2 = Dstring.FromBytes(buffer, offset + 228, 36);
             LVInfo3 = Dstring.FromBytes(buffer, offset + 264, 36);
             ImplementationID = EndianUtilities.ToStruct<ApplicationEntityIdentifier>(buffer, offset + 300);
-            ImplementationUse = buffer[(offset + 332)..(offset + 460)];
+            ImplementationUse = buffer.Slice((offset + 332), (offset + 460));
 
             return Size;
         }

--- a/Ps2IsoTools/UDF/Descriptors/VolumeStructure/LogicalVolumeDescriptor.cs
+++ b/Ps2IsoTools/UDF/Descriptors/VolumeStructure/LogicalVolumeDescriptor.cs
@@ -1,4 +1,5 @@
 ﻿using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 using Ps2IsoTools.UDF.CharacterSet;
 using Ps2IsoTools.UDF.EntityIdentifiers;
 using Ps2IsoTools.UDF.PartitionMaps;
@@ -60,11 +61,11 @@ namespace Ps2IsoTools.UDF.Descriptors
             LogicalVolumeIdentifier = Dstring.FromBytes(buffer, offset + 84, 128);
             LogicalBlockSize = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 212);
             DomainIdentifier = EndianUtilities.ToStruct<DomainEntityIdentifier>(buffer, offset + 216);
-            LogicalVolumeContentsUse = buffer[(offset + 248)..(offset + 264)];
+            LogicalVolumeContentsUse = buffer.Slice((offset + 248), (offset + 264));
             MapTableLength = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 264);
             NumberofPartitionMaps = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 268);
             ImplementationIdentifier = EndianUtilities.ToStruct<ImplementationEntityIdentifier>(buffer, offset + 272);
-            ImplementationUse = buffer[(offset + 304)..(offset + 432)];
+            ImplementationUse = buffer.Slice((offset + 304), (offset + 432));
             IntegritySequenceExtent = EndianUtilities.ToStruct<ExtentDescriptor>(buffer, offset + 432);
 
             int pmOffset = 0;
@@ -93,7 +94,7 @@ namespace Ps2IsoTools.UDF.Descriptors
             Array.Copy(ImplementationUse, 0, buffer, offset + 304, ImplementationUse.Length);
             IntegritySequenceExtent.WriteTo(buffer, offset + 432);
             int pmOffset = 0;
-            for(int i = 0; i < PartitionMaps.Length; i++)
+            for (int i = 0; i < PartitionMaps.Length; i++)
             {
                 PartitionMaps[i].WriteTo(buffer, offset + 440 + pmOffset);
                 pmOffset += PartitionMaps[i].Size;

--- a/Ps2IsoTools/UDF/Descriptors/VolumeStructure/PartitionDescriptor.cs
+++ b/Ps2IsoTools/UDF/Descriptors/VolumeStructure/PartitionDescriptor.cs
@@ -1,4 +1,5 @@
 ﻿using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 using Ps2IsoTools.UDF.EntityIdentifiers;
 
 namespace Ps2IsoTools.UDF.Descriptors.VolumeStructure
@@ -50,7 +51,7 @@ namespace Ps2IsoTools.UDF.Descriptors.VolumeStructure
             PartitionStartingLocation = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 188);
             PartitionLength = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 192);
             ImplementationIdentifier = EndianUtilities.ToStruct<ImplementationEntityIdentifier>(buffer, offset + 196);
-            ImplementationUse = buffer[(offset + 228)..(offset + 356)];
+            ImplementationUse = buffer.Slice((offset + 228), (offset + 356));
 
             return Size;
         }
@@ -99,7 +100,7 @@ namespace Ps2IsoTools.UDF.Descriptors.VolumeStructure
                 PartitionIntegrityTable = EndianUtilities.ToStruct<ShortAllocationDescriptor>(buffer, offset + 16);
                 FreedSpaceTable = EndianUtilities.ToStruct<ShortAllocationDescriptor>(buffer, offset + 24);
                 FreedSpaceBitmap = EndianUtilities.ToStruct<ShortAllocationDescriptor>(buffer, offset + 32);
-                Reserved = buffer[(offset + 40)..(offset + 128)];
+                Reserved = buffer.Slice((offset + 40), (offset + 128));
 
                 return Size;
             }

--- a/Ps2IsoTools/UDF/Descriptors/VolumeStructure/PrimaryVolumeDescriptor.cs
+++ b/Ps2IsoTools/UDF/Descriptors/VolumeStructure/PrimaryVolumeDescriptor.cs
@@ -1,4 +1,5 @@
 ﻿using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 using Ps2IsoTools.UDF.CharacterSet;
 using Ps2IsoTools.UDF.EntityIdentifiers;
 using Ps2IsoTools.UDF.Strings;
@@ -38,7 +39,7 @@ namespace Ps2IsoTools.UDF.Descriptors
             {
                 TagIdentifier = TagIdentifier.PrimaryVolumeDescriptor,
                 DescriptorCRCLength = (ushort)(Size - 16),
-                TagLocation = sector,                
+                TagLocation = sector,
             };
             VolumeDescriptorSequenceNumber = descriptorSequenceNumber;
             PrimaryVolumeDescriptorNumber = 0;
@@ -82,7 +83,7 @@ namespace Ps2IsoTools.UDF.Descriptors
             ApplicationIdentifier = EndianUtilities.ToStruct<ApplicationEntityIdentifier>(buffer, offset + 344);
             RecordingTimeStamp = EndianUtilities.ToStruct<TimeStamp>(buffer, offset + 376);
             ImplementationIdentifier = EndianUtilities.ToStruct<ImplementationEntityIdentifier>(buffer, offset + 388);
-            ImplementationUse = buffer[(offset + 420)..(offset + 484)];
+            ImplementationUse = buffer.Slice((offset + 420), (offset + 484));
             PredecessorVolumeDescriptorSequenceLocation = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 484);
             Flags = EndianUtilities.ToUInt16LittleEndian(buffer, offset + 488);
 

--- a/Ps2IsoTools/UDF/EntityIdentifiers/EntityIdentifier.cs
+++ b/Ps2IsoTools/UDF/EntityIdentifiers/EntityIdentifier.cs
@@ -1,5 +1,6 @@
-﻿using Ps2IsoTools.DiscUtils.Utils;
-using System.Text;
+﻿using System.Text;
+using Ps2IsoTools.DiscUtils.Utils;
+using Ps2IsoTools.Extensions;
 
 namespace Ps2IsoTools.UDF.EntityIdentifiers
 {
@@ -13,8 +14,8 @@ namespace Ps2IsoTools.UDF.EntityIdentifiers
         public int ReadFrom(byte[] buffer, int offset)
         {
             Flags = buffer[offset];
-            Identifier = Encoding.ASCII.GetString(buffer[(offset + 1)..(offset + 24)]);
-            Suffix = buffer[(offset + 24)..(offset + 32)];
+            Identifier = Encoding.ASCII.GetString(buffer.Slice((offset + 1), (offset + 24)));
+            Suffix = buffer.Slice((offset + 24), (offset + 32));
 
             return Size;
         }

--- a/Ps2IsoTools/UDF/Strings/Dstring.cs
+++ b/Ps2IsoTools/UDF/Strings/Dstring.cs
@@ -119,7 +119,7 @@ namespace Ps2IsoTools.UDF.Strings
             }
             data[0] = (byte)CompressionID;
             if (DataLength > MinLength)
-                data[^1] = (byte)(MinLength);
+                data[data.Length - 1] = (byte)(MinLength);
             return data;
         }
 
@@ -133,7 +133,7 @@ namespace Ps2IsoTools.UDF.Strings
         public static Dstring FromBytes(byte[] buffer, int offset, int count, bool padded = true)
         {
             if (padded)
-                return new Dstring(ReadDCharacters(buffer, offset, buffer[offset + count -1]), (CompressionID)buffer[offset], count);
+                return new Dstring(ReadDCharacters(buffer, offset, buffer[offset + count - 1]), (CompressionID)buffer[offset], count);
             else
                 return new Dstring(ReadDCharacters(buffer, offset, count), (CompressionID)buffer[offset]);
         }

--- a/Ps2IsoTools/UDF/UdfReader.cs
+++ b/Ps2IsoTools/UDF/UdfReader.cs
@@ -7,8 +7,8 @@ using Ps2IsoTools.UDF.Descriptors.FileStructure;
 using Ps2IsoTools.UDF.Descriptors.VolumeStructure;
 using Ps2IsoTools.UDF.Files;
 using Ps2IsoTools.UDF.Partitions;
-using File = Ps2IsoTools.UDF.Files.File;
 using Directory = Ps2IsoTools.UDF.Files.Directory;
+using File = Ps2IsoTools.UDF.Files.File;
 
 namespace Ps2IsoTools.UDF
 {
@@ -157,7 +157,7 @@ namespace Ps2IsoTools.UDF
         private List<string> GetDirectoryNames(string dirName, Directory dir)
         {
             List<string> names = new();
-            foreach(FileIdentifier fi in dir.AllEntries)
+            foreach (FileIdentifier fi in dir.AllEntries)
             {
                 string n = $"{dirName}\\{fi.FileName}";
                 if (fi.IsDirectory)
@@ -165,13 +165,13 @@ namespace Ps2IsoTools.UDF
                 else
                     names.Add(n);
             }
-            return names;            
+            return names;
         }
 
         public bool CopyFile(FileIdentifier file, string filePath = "")
         {
             if (filePath == "")
-                filePath = file.FileName.Split(";")[0];
+                filePath = file.FileName.Split(';')[0];
             FileInfo fi = new FileInfo(filePath);
             Stream fileStream = GetFileStream(file);
             using (FileStream stream = fi.Create())


### PR DESCRIPTION
As part of another [project](https://github.com/intelorca/biorand) I am working on. I needed a .NET standard 2.0 compatible version of this library.

Here are my changes to do that. Mostly replacing the array subscript syntax with an extension method so that it can use Array.Copy instead.

If you are interested in pushing a .NET standard 2.0 version to nuget, then this can be looked at. If not, then you can close this and I will just refer to this version via a submodule from the project.